### PR TITLE
Allow to start mediawriter on wayland

### DIFF
--- a/org.fedoraproject.MediaWriter.json
+++ b/org.fedoraproject.MediaWriter.json
@@ -9,6 +9,7 @@
     "rename-icon": "mediawriter",
     "finish-args": [
         "--socket=x11",
+        "--socket=wayland",
         "--device=dri",
         "--filesystem=host",
         "--share=network",


### PR DESCRIPTION
With KDE running on wayland you need to be able to run MediaWriter on wayland. This was not possible before with old flatpak portals support, where we were stuck with X11, but this is no longer true and wayland is used when possible.