### PR TITLE
Switch download url to https

### DIFF
--- a/org.fedoraproject.MediaWriter.json
+++ b/org.fedoraproject.MediaWriter.json
@@ -23,7 +23,7 @@
             "sources": [
                 {
                     "type": "git",
-                    "url": "http://github.com/MartinBriza/MediaWriter",
+                    "url": "https://github.com/MartinBriza/MediaWriter",
                     "tag": "4.1.5"
                 }
             ]


### PR DESCRIPTION
Mostly submitted this pull request because the build on flathub is out of date, it is using commit 0fa051b5, from April 2019.

Hopefully after this is merged flathub will build properly from master.