### PR TITLE
Allow access to all devices

### DIFF
--- a/org.fedoraproject.MediaWriter.json
+++ b/org.fedoraproject.MediaWriter.json
@@ -7,7 +7,7 @@
     "finish-args": [
         "--socket=x11",
         "--socket=wayland",
-        "--device=dri",
+        "--device=all",
         "--filesystem=host",
         "--share=network",
         "--share=ipc",


### PR DESCRIPTION
This is necessary (at least for me) to be able to write to a USB stick.

I tried this by running with `flatpak run --device=all` locally but it seems since writing to a USB stick is a primary function of this application it should be the default.