### PR TITLE
Use KDE 6.7 runtime

### DIFF
--- a/org.fedoraproject.MediaWriter.json
+++ b/org.fedoraproject.MediaWriter.json
@@ -1,7 +1,7 @@
 {
     "id": "org.fedoraproject.MediaWriter",
     "runtime": "org.kde.Platform",
-    "runtime-version": "6.6",
+    "runtime-version": "6.7",
     "sdk": "org.kde.Sdk",
     "command": "mediawriter",
     "finish-args": [


### PR DESCRIPTION
As the new stable version of KDE Runtime is released. This PR updates the runtime to KDE 6.7.