### PR TITLE
Disable QML cache through an env variable

### DIFF
--- a/org.fedoraproject.MediaWriter.json
+++ b/org.fedoraproject.MediaWriter.json
@@ -12,7 +12,8 @@
         "--share=network",
         "--share=ipc",
         "--system-talk-name=org.freedesktop.UDisks2",
-        "--talk-name=org.freedesktop.Notifications"
+        "--talk-name=org.freedesktop.Notifications",
+        "--env=QML_DISABLE_DISK_CACHE=1"
     ],
     "cleanup": [
         "/include",


### PR DESCRIPTION
It looks updating from older version to newer can cause issues with a stale QML cache. This enforced to not use the cache, which shouldn't be major problem for us, but at least we ensure the app will start properly

Fixes https://github.com/flathub/org.fedoraproject.MediaWriter/issues/57